### PR TITLE
Fix/scroll-overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ git log | hex-ray <subcommand>
 >
 > ## Why Hexadecimal?
 >
-> The number of distinct values any sequence of digits can represent is given by the base raised to the power of the number of digits in the sequence. For example, a 2-bit binary (base-2) sequence can represent 2<sup>2</sup> = 4 distinct values; namely 00, 01, 10, 11. The 8 binary digits in a byte can represent 2<sup>8</sup> = 256 distinct values, usually interpreted as the numbers 0 to 255. Similarly, two-digit hexadecimal numbers can represent 16<sup>2</sup> distinct values - also 256. This convenient correspondence is why programmers like hexadecimal notation so much - it gives us a compact way of representing all possible byte values with just two digits!
+> The number of distinct values any sequence of digits can represent is given by the base raised to the power of the number of digits in the sequence. For example, a 2-bit binary (base-2) sequence can represent 2<sup>2</sup> = 4 distinct values; namely 00, 01, 10, 11. The 8 binary digits in a byte can represent 2<sup>8</sup> = 256 distinct values, usually interpreted as the numbers 0 to 255. Similarly, two-digit hexadecimal (base-16) numbers can represent 16<sup>2</sup> distinct values - also 256. This convenient correspondence is why programmers like hexadecimal notation so much - it gives us a compact way of representing all possible byte values with just two digits!
 >
 > Actually, it's even better than you might suspect at first. Each hexadecimal digit aligns cleanly with four bits of the corresponding byte so the hexadecimal number 0x12 corresponds to the byte 0001_0010 and the hexadecimal number 0x34 corresponds to 0011_0100. This makes it really easy to read bit patterns directly from hex notation!
 >
 
 > [!NOTE]
 > 
-> If you haven't met it before, the 0x prefix is used to indicate that a number is written in hexadecimal base. Similarly 0o can be used to indicate octal (base-8) and 0b to indicate binary (base-2).
+> The `0x` prefix indicates that a number is written in hexadecimal (base-16) format. Similarly, `0o` is used to indicate octal (base-8) and `0b` to indicate binary (base-2).
 
 ### `NO_COLOR` Environment Variable
 

--- a/src/cli/cmd/inspect/events.rs
+++ b/src/cli/cmd/inspect/events.rs
@@ -132,12 +132,12 @@ impl App {
     fn adjust_scroll_view(&mut self) {
         // Now, if the selection falls above the first row in the view ...
         if self.selected < self.rows(self.scroll_offset) {
-            let rows_to_scroll = self.row(self.scroll_offset - self.selected);
+            let rows_to_scroll = self.row(self.rows(self.scroll_offset + 1) - self.selected);
             self.scroll_offset = self.scroll_offset.saturating_sub(rows_to_scroll);
         } else if self.selected >= self.rows(self.rows_per_page + self.scroll_offset) {
             // Otherwise if the selection goes beyond the last row in the view, scroll down by x rows
             let rows_to_scroll =
-                self.row(self.selected - (self.rows_per_page + self.scroll_offset));
+                self.row(self.selected - self.rows(self.rows_per_page + self.scroll_offset)) + 1;
             self.scroll_offset += rows_to_scroll;
         }
     }

--- a/src/cli/cmd/inspect/ui.rs
+++ b/src/cli/cmd/inspect/ui.rs
@@ -70,7 +70,7 @@ impl App {
         // Determine the starting and ending rows for the data slice
         let start = self.scroll_offset;
         let end = std::cmp::min(
-            self.scroll_offset + self.rows_per_page * self.cfg.size,
+            self.scroll_offset + self.rows(self.rows_per_page),
             self.data.len(),
         );
 


### PR DESCRIPTION
Bad logic in `adjust_scroll_view` was causing overflow when selecting the rows for the UI.